### PR TITLE
add feature to extend KnifeProMaxDiff protection to high level victims

### DIFF
--- a/addons/sourcemod/scripting/gungame/config.h
+++ b/addons/sourcemod/scripting/gungame/config.h
@@ -74,6 +74,7 @@ new Float:g_Cfg_HandicapUpdate;
 new g_Cfg_KnifeProRecalcPoints = 0;
 new bool:g_Cfg_HandicapSkipBots = false;
 new g_Cfg_KnifeProMaxDiff = 0;
+new bool:g_Cfg_KnifeProMaxDiffIsBi = false;
 new g_Cfg_MultiLevelAmount = 3;
 new g_Cfg_HandicapTimesPerMap = 0;
 new g_cfgDisableRtvLevel = 0;

--- a/addons/sourcemod/scripting/gungame/config.sp
+++ b/addons/sourcemod/scripting/gungame/config.sp
@@ -122,6 +122,8 @@ public GG_ConfigKeyValue(const String:key[], const String:value[])
                 SetConVarInt(g_Cvar_MultiLevelAmount, g_Cfg_MultiLevelAmount);
             } else if(strcmp("KnifeProMaxDiff", key, false) == 0) {
                 g_Cfg_KnifeProMaxDiff = StringToInt(value);
+            } else if(strcmp("KnifeProMaxDiffIsBi", key, false) == 0) {
+                g_Cfg_KnifeProMaxDiffIsBi = bool:StringToInt(value);
             } else if(strcmp("HandicapSkipBots", key, false) == 0) {
                 g_Cfg_HandicapSkipBots = bool:StringToInt(value);
             } else if(strcmp("KnifeProRecalcPoints", key, false) == 0) {

--- a/addons/sourcemod/scripting/gungame/event.sp
+++ b/addons/sourcemod/scripting/gungame/event.sp
@@ -335,6 +335,8 @@ public _PlayerDeath(Handle:event, const String:name[], bool:dontBroadcast)
         for (;;)
         {
             new VictimLevel = PlayerLevel[Victim];
+            new LevelDiff =  level - VictimLevel;
+            new BitMask;
 
             if ( VictimLevel < KnifeProMinLevel )
             {
@@ -342,7 +344,13 @@ public _PlayerDeath(Handle:event, const String:name[], bool:dontBroadcast)
                 break;
             }
 
-            if ( g_Cfg_KnifeProMaxDiff && ( g_Cfg_KnifeProMaxDiff < level - VictimLevel ) )
+            if ( g_Cfg_KnifeProMaxDiff && g_Cfg_KnifeProMaxDiffIsBi ) {
+                // Get absolute value
+                BitMask = LevelDiff >> 31;
+                LevelDiff = (BitMask ^ LevelDiff) - BitMask;
+            }
+
+            if ( g_Cfg_KnifeProMaxDiff && ( g_Cfg_KnifeProMaxDiff < LevelDiff ) )
             {
                 CPrintToChatEx(Killer, Victim, "%t", "You can not steal level from %s, your levels difference is more then %d", vName, g_Cfg_KnifeProMaxDiff);
                 break;

--- a/cfg/gungame/csgo/gungame.config.txt
+++ b/cfg/gungame/csgo/gungame.config.txt
@@ -319,11 +319,25 @@
         "KnifeProRecalcPoints" "0"
         
         /**
-         * Maximum level difference between players to allow steal level 
+         * Maximum level difference between players to allow steal level.
+         * By default does not protect victims who are >N levels higher than
+         * the killer. 
+         * See also: KnifeProMaxDiffIsBi
+         *
          * 0 - Disabled
          * 1..N - Level difference between killer and victim
          */
         "KnifeProMaxDiff" "0"
+
+        /**
+         * Also apply KnifeProMaxDiff to victims who are >N levels higher than
+         * the killer (fully bidirectional difference check).
+         * See also: KnifeProMaxDiff
+         *
+         * 0 - Disable fully bidirectional difference check
+         * 1 - Enable fully bidirectional difference check
+         */
+        "KnifeProMaxDiffIsBi" "0"
 
         /**
          * Disable level down on knifepro.
@@ -679,9 +693,9 @@
         "LevelDown"         "gungame/smb3_powerdown.mp3"
         "Triple"            "gungame/smb_star.mp3"
         "Autoff"            "gungame/smb_warning2.mp3"
-        "MultiKill"         "gungame/multikill.mp3"   // (Ñ) VALVE
+        "MultiKill"         "gungame/multikill.mp3"   // (ï¿½) VALVE
         /* Put each song filename in this list seperated by commas */
-        "Winner"            "gungame/winner.mp3"      // (Ñ) VALVE
-        "WarmupTimerSound"  "gungame/timer.mp3"       // (Ñ) VALVE
+        "Winner"            "gungame/winner.mp3"      // (ï¿½) VALVE
+        "WarmupTimerSound"  "gungame/timer.mp3"       // (ï¿½) VALVE
     }
 }

--- a/cfg/gungame/css/gungame.config.txt
+++ b/cfg/gungame/css/gungame.config.txt
@@ -319,11 +319,25 @@
         "KnifeProRecalcPoints" "0"
         
         /**
-         * Maximum level difference between players to allow steal level 
+         * Maximum level difference between players to allow steal level.
+         * By default does not protect victims who are >N levels higher than
+         * the killer. 
+         * See also: KnifeProMaxDiffIsBi
+         *
          * 0 - Disabled
          * 1..N - Level difference between killer and victim
          */
         "KnifeProMaxDiff" "0"
+
+        /**
+         * Also apply KnifeProMaxDiff to victims who are >N levels higher than
+         * the killer (fully bidirectional difference check).
+         * See also: KnifeProMaxDiff
+         *
+         * 0 - Disable fully bidirectional difference check
+         * 1 - Enable fully bidirectional difference check
+         */
+        "KnifeProMaxDiffIsBi" "0"
 
         /**
          * Disable level down on knifepro.
@@ -639,9 +653,9 @@
         "LevelDown"         "gungame/smb3_powerdown.mp3"
         "Triple"            "gungame/smb_star.mp3"
         "Autoff"            "gungame/smb_warning2.mp3"
-        "MultiKill"         "gungame/multikill.mp3"   // (Ñ) VALVE
+        "MultiKill"         "gungame/multikill.mp3"   // (ï¿½) VALVE
         /* Put each song filename in this list seperated by commas */
-        "Winner"            "gungame/winner.mp3"      // (Ñ) VALVE
-        "WarmupTimerSound"  "gungame/timer.mp3"       // (Ñ) VALVE
+        "Winner"            "gungame/winner.mp3"      // (ï¿½) VALVE
+        "WarmupTimerSound"  "gungame/timer.mp3"       // (ï¿½) VALVE
     }
 }


### PR DESCRIPTION
Thank you for this mod, it has given me weeks of fun.

The mathematics for the KnifeProMaxDiff check mean that high level
victims are not protected from low level victims. E.g. if
KnifeProMaxDiff = 5
VictimLevel = 20
KillerLevel = 1
Killer can steal from Victim even though difference is > 5. But, if the
reverse happens the lower level player has protection.

This feature would add a config variable KnifeProMaxDiffIsBi to
enable a fully bidirectional difference check.  In other words,
abs(difference) is used instead of difference.

[Mock example in JavaScript](https://jsfiddle.net/zovmn5rs/1/).

For further discussion, please see:
http://support.bruss.org.ru/viewtopic.php?f=1&t=29599

# This needs compiling and testing before merging!